### PR TITLE
Truncate message longer than 300 symbols

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -380,7 +380,7 @@ export function activate(context: vscode.ExtensionContext) {
                     // after the source-code line in the editor, and text rendering options.
                     const decInstanceRenderOptions: vscode.DecorationInstanceRenderOptions = {
                         after: {
-                            contentText: messagePrefix + aggregatedDiagnostic.arrayDiagnostics[0].message,
+                            contentText: truncate(messagePrefix + aggregatedDiagnostic.arrayDiagnostics[0].message),
                             fontStyle: GetAnnotationFontStyle(),
                             fontWeight: GetAnnotationFontWeight(),
                             margin: GetAnnotationMargin(),
@@ -459,6 +459,10 @@ export function activate(context: vscode.ExtensionContext) {
 
             _statusBarItem.show();
         }
+    }
+
+    function truncate(str: string): string {
+        return str.length > 300 ? str.slice(0, 300) + '…' : str;
     }
 }
 


### PR DESCRIPTION
Fixes #19

Users will probably hit that issue in vscode **1.32.0**.

You can test it in [Insiders version](https://code.visualstudio.com/insiders/).

* Open `keybindings.json`
* Mess up with any `command` property
* Now that warning `75000` symbols long 